### PR TITLE
[Bugfix] Réparation des cartes et du title du site

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 _Un résumé de l’objectif de la PR_
 
-_Précisez si c’est un bugfix, une nouvelle fonctionnalité… Expliquez rapidement le gain "fonctionnel" de vos modifications._
+_Précisez si c’est un bugfix, une nouvelle fonctionnalité… Expliquez rapidement le gain « fonctionnel » de vos modifications._
 
 ## 🔍 Implémentation
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,22 @@
+## 🎯 Objectif
+
+_Un résumé de l’objectif de la PR_
+
+_Précisez si c’est un bugfix, une nouvelle fonctionnalité… Expliquez rapidement le gain "fonctionnel" de vos modifications._
+
+## 🔍 Implémentation
+
+- _Une liste des modifications_
+
+## ⚠️ Informations supplémentaires
+
+_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._
+
+## 🏕 Amélioration continue
+
+- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_
+
+## 🖼️ Images
+
+_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
+

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -19,4 +19,3 @@ _(optionnel) Documentation, commandes à lancer, variables d’environnement, et
 ## 🖼️ Images
 
 _(optionnel) Une ou plusieurs captures d’écran, si pertinent_
-

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 
 # VSCode
 .VSCode
+.vscode/

--- a/config/settings.py
+++ b/config/settings.py
@@ -92,7 +92,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                "dsfr.context_processors.site_config",
                 "wagtail.contrib.settings.context_processors.settings",
                 "wagtailmenus.context_processors.wagtailmenus",
             ],

--- a/content_manager/templates/content_manager/blocks/card.html
+++ b/content_manager/templates/content_manager/blocks/card.html
@@ -11,7 +11,7 @@
                     {{ block.value.title }}
                 {% if block.value.url or block.value.document.url %}</a>{% endif %}
             </h3>
-            <p class="fr-card__desc">{{ block.value.text|linebreaksbr }}</p>
+            <p class="fr-card__desc">{{ block.value.description|linebreaksbr }}</p>
         </div>
     </div>
     <div class="fr-card__header">

--- a/content_manager/templates/content_manager/content_page.html
+++ b/content_manager/templates/content_manager/content_page.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static dsfr_tags wagtailcore_tags wagtailimages_tags %}
 {% block title %}
-    <title>{{ page.seo_title|default:page.title }} — {{ SITE_CONFIG.site_title }}</title>
+    <title>{{ page.seo_title|default:page.title }} — {{ settings.content_manager.CmsDsfrConfig.site_title }}</title>
 {% endblock title %}
 {% if page.search_description %}
     {% block description %}

--- a/content_manager/tests/test_views.py
+++ b/content_manager/tests/test_views.py
@@ -8,9 +8,7 @@ from content_manager.models import ContentPage
 class ContentPageTestCase(WagtailPageTestCase):
     def setUp(self):
         home = Page.objects.get(slug="home")
-        self.user = User.objects.create_user("test", "test@test.test", "pass")
-        self.user.is_superuser = True
-        self.user.is_staff = True
+        self.user = User.objects.create_superuser("test", "test@test.test", "pass")
         self.user.save()
         self.content_page = home.add_child(
             instance=ContentPage(

--- a/content_manager/tests/test_views.py
+++ b/content_manager/tests/test_views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.models import User
+from wagtail.models import Page
+from wagtail.test.utils import WagtailPageTestCase
+
+from content_manager.models import ContentPage
+
+
+class ContentPageTestCase(WagtailPageTestCase):
+    def setUp(self):
+        home = Page.objects.get(slug="home")
+        self.user = User.objects.create_user("test", "test@test.test", "pass")
+        self.user.is_superuser = True
+        self.user.is_staff = True
+        self.user.save()
+        self.content_page = home.add_child(
+            instance=ContentPage(
+                title="Page de contenu",
+                slug="content-page",
+                owner=self.user,
+            )
+        )
+        self.content_page.save()
+
+    def test_content_page_is_renderable(self):
+        self.assertPageIsRenderable(self.content_page)
+
+    def test_content_page_has_minimal_content(self):
+        url = self.content_page.url
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            "<title>Page de contenu — Titre du site</title>",
+        )

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   {% dsfr_favicon %}
   {% block extra_css %}{% endblock extra_css %}
 
-  {% block title %}<title>{% if title %}{{ title }} — {{ settings.content_manager.CmsDsfrConfig.site_title }}{% else %}{{ settings.content_manager.CmsDsfrConfig.site_title }}{% endif %}</title>{% endblock title %}
+  {% block title %}<title>{% if title %}{{ title }} — {% endif %}{{ settings.content_manager.CmsDsfrConfig.site_title }}</title>{% endblock title %}
   {% block tracking %}
     {% if settings.content_manager.AnalyticsSettings.head_scripts %}
       {{settings.content_manager.AnalyticsSettings.head_scripts|safe}}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   {% dsfr_favicon %}
   {% block extra_css %}{% endblock extra_css %}
 
-  {% block title %}<title>{% if title %}{{ title }} — {{ SITE_CONFIG.site_title }}{% else %}{{ SITE_CONFIG.site_title }}{% endif %}</title>{% endblock title %}
+  {% block title %}<title>{% if title %}{{ title }} — {{ settings.content_manager.CmsDsfrConfig.site_title }}{% else %}{{ settings.content_manager.CmsDsfrConfig.site_title }}{% endif %}</title>{% endblock title %}
   {% block tracking %}
     {% if settings.content_manager.AnalyticsSettings.head_scripts %}
       {{settings.content_manager.AnalyticsSettings.head_scripts|safe}}


### PR DESCRIPTION
## 🎯 Objectif

Résout #53 : Problème remonté par Sabrina Hedroug ([Programme 10%](https://www.10pourcent.etalab.gouv.fr/)) : le texte des cartes ne s’affiche plus depuis la mise à jour. Problème urgent, la nouvelle version du site sera publiée le 28.

Par ailleurs, le nom du site n’est plus inclus dans la balise title depuis la mise à jour.

## 🔍 Implémentation
- [x] Remettre le champ description dans les cartes
- [x] Remettre le nom du site dans le title


## ⚠️ Informations supplémentaires
- Le template `card.html` inclut un champ optionnel pour un badge pas géré par le modèle, j'ai laissé comme ça, je pense ajouter la prise en charge des champs avancés dans une PR séparée.

## 🏕 Amélioration continue
- [x] Ajouter le modèle pour les PR
- [x] Mettre en place un premier test unitaire

## 🖼️ Images
- Résultat attendu :
![Capture d’écran du 2023-11-23 11-02-26](https://github.com/numerique-gouv/content-manager/assets/765956/0b52021d-ec92-4aca-84ed-b198727a5fcc)

