### PR TITLE
Ajout d’un fil d’Ariane

### DIFF
--- a/content_manager/templates/content_manager/blocks/breadcrumbs.html
+++ b/content_manager/templates/content_manager/blocks/breadcrumbs.html
@@ -1,0 +1,20 @@
+
+{% if self.get_ancestors|length > 1 %}
+<nav role="navigation" class="fr-breadcrumb" aria-label="vous êtes ici :">
+    <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="page-breadcrumb">Voir le fil d’Ariane</button>
+    <div class="fr-collapse" id="page-breadcrumb">
+        <ol class="fr-breadcrumb__list">
+            {% for p in self.get_ancestors %}
+                {% if p.is_root == False %}
+                    <li>
+                        <a class="fr-breadcrumb__link" href="{{ p.url }}">{{ p.title }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+            <li>
+                <a class="fr-breadcrumb__link" aria-current="page">{{ self.title }}</a>
+            </li>
+        </ol>
+    </div>
+</nav>
+{% endif %}

--- a/content_manager/templates/content_manager/content_page.html
+++ b/content_manager/templates/content_manager/content_page.html
@@ -37,10 +37,14 @@
     {% for block in page.body %}
         {% if block.block_type == 'hero' %}
             {% include "content_manager/blocks/hero.html" %}
+            <div class="fr-container">
+                {% include "content_manager/blocks/breadcrumbs.html" %}
+            </div>
         {% elif block.block_type == 'title' %}
             <div class="fr-container fr-mt-6w">
                 <div class="fr-grid-row fr-grid-row--gutters">
                     <div class="fr-col-12{% if not block.value.large %} fr-col-offset-md-2 fr-col-md-8{% endif %}">
+                        {% include "content_manager/blocks/breadcrumbs.html" %}
                         <h1 class="fr-display--sm">{{ block.value.title }}</h1>
                     </div>
                 </div>


### PR DESCRIPTION
## 🎯 Objectif
Les pages autres que l’accueil doivent afficher un fil d’Ariane conforme au DSFR, tenant automatiquement compte de l'arborescence des pages Wagtail

- Le fil d'Ariane doit s'afficher au-dessus du titre principal de la page
- Le fil d'Ariane ne doit pas s'afficher sur la page d'accueil
- Le fil d'Ariane doit s'afficher au-dessous de la section promotionnelle (pas sûr de pourquoi une page autre que l'accueil devrait avoir une section promotionnelle mais au cas où...)

## 🔍 Implémentation
- [x] Création du bloc breadcrumbs

## 🖼️ Images
Page niveau 1 avec section promotionnelle
![Capture d’écran du 2023-12-05 12-11-42](https://github.com/numerique-gouv/content-manager/assets/765956/ec1a9195-89e5-4996-b888-c5c1b4467bb9)

Page niveau 2 avec un titre normal
![Capture d’écran du 2023-12-05 12-11-55](https://github.com/numerique-gouv/content-manager/assets/765956/9f0a800c-f412-4a37-bb63-b323717b5774)