### PR TITLE
fix: dockerfile copy multiple files (067)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 
 WORKDIR $APP_DIR
 
-COPY pyproject.toml poetry.lock .
+COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
 COPY --chown=app:app . .


### PR DESCRIPTION
Error STEP 21 when trying to copy multiple files to "."

## 🎯 Objectif

Fix #67

Permet de lancer l'appli via Docker (avec #68 et #69)

## 🔍 Implémentation

- Modification du chemin de destination des fichiers copiés dans le Dockerfile

## ⚠️ Informations supplémentaires

Aucune

## 🏕 Amélioration continue

Aucun

## 🖼️ Images

Cf #67 
