### PR TITLE
fix: load env file in docker dev service (069)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
 
   web:
     build: .
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@db:${DATABASE_PORT}/${DATABASE_NAME}
     ports:


### PR DESCRIPTION
## 🎯 Objectif

Fix #69

Permet de lancer l'appli via Docker (avec #67 et #68)


## 🔍 Implémentation

- Ajout de l'env file au service `web` du *docker-compose*

## ⚠️ Informations supplémentaires

Aucune

## 🏕 Amélioration continue

Aucun

## 🖼️ Images

cf #69 
