### PR TITLE
Permettre de partager un hébergement S3 entre plusieurs instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,15 @@
 SECRET_KEY=
 DEBUG=False
 HOST_PROTO=http
-HOST_URL=localhost # use 0.0.0.0 for Docker
+# HOST_URL: use 0.0.0.0 for Docker
+HOST_URL=localhost
 ALLOWED_HOSTS=localhost, 0.0.0.0
 HOST_PORT=8000
 SITE_NAME=Gestionnaire de contenus
 MEDIA_ROOT=
 
-USE_DOCKER=0 # Set 1 to use Docker
+# USE_DOCKER: Set 1 to use Docker
+USE_DOCKER=0
 
 DATABASE_NAME=djdb
 DATABASE_USER=dju
@@ -16,9 +18,11 @@ DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_URL=postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
 
-S3_HOST= # domain only, with no protocol or trailing slash.
+# S3_HOST: domain only, with no protocol or trailing slash.
+S3_HOST=
 S3_KEY_ID=
 S3_KEY_SECRET=
 S3_BUCKET_NAME=
 S3_BUCKET_REGION=eu-west-3
-S3_LOCATION= # If the S3 bucket is shared, add a unique folder name
+# S3_LOCATION: If the S3 bucket is shared, add a unique folder name
+S3_LOCATION=

--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,4 @@ S3_KEY_ID=
 S3_KEY_SECRET=
 S3_BUCKET_NAME=
 S3_BUCKET_REGION=eu-west-3
+S3_LOCATION= # If the S3 bucket is shared, add a unique folder name

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ HOST_URL=localhost # use 0.0.0.0 for Docker
 ALLOWED_HOSTS=localhost, 0.0.0.0
 HOST_PORT=8000
 SITE_NAME=Gestionnaire de contenus
+MEDIA_ROOT=
 
 USE_DOCKER=0 # Set 1 to use Docker
 

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 SECRET_KEY=
 DEBUG=False
 HOST_PROTO=http
-# HOST_URL: use 0.0.0.0 for Docker
+# HOST_URL and ALLOWED_HOSTS: use 0.0.0.0 for Docker
 HOST_URL=localhost
-ALLOWED_HOSTS=localhost, 0.0.0.0
+ALLOWED_HOSTS=localhost, 127.0.0.1
 HOST_PORT=8000
 SITE_NAME=Gestionnaire de contenus
 MEDIA_ROOT=

--- a/config/settings.py
+++ b/config/settings.py
@@ -181,13 +181,14 @@ if os.getenv("S3_HOST"):
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_URL = "medias/"
+    MEDIA_ROOT = os.path.join(BASE_DIR, os.getenv("MEDIA_ROOT", ""))
 
 # Django Sass
 SASS_PROCESSOR_ROOT = os.path.join(BASE_DIR, "static/css")
 SASS_PROCESSOR_AUTO_INCLUDE = False
 
 STATIC_URL = "static/"
-STATIC_ROOT = "staticfiles"
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -175,6 +175,7 @@ if os.getenv("S3_HOST"):
     AWS_S3_ENDPOINT_URL = f"{os.getenv('S3_PROTOCOL', 'https')}://{os.getenv('S3_HOST')}"
     AWS_STORAGE_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "set-bucket-name")
     AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_BUCKET_REGION", "fr")
+    AWS_S3_FILE_OVERWRITE = False
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"
     AWS_LOCATION = os.getenv("S3_LOCATION", "")

--- a/config/settings.py
+++ b/config/settings.py
@@ -177,6 +177,7 @@ if os.getenv("S3_HOST"):
     AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_BUCKET_REGION", "fr")
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"
+    AWS_LOCATION = os.getenv("S3_LOCATION", "")
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_URL = "medias/"


### PR DESCRIPTION
## 🎯 Objectif
- Permettre à plusieurs instances du CMS de partager un bucket S3 (notamment pour celles de démo), chacune ayant son répertoire propre à la racine du bucket.
 
## 🔍 Implémentation

- [x] Ajouter un setting `AWS_LOCATION` et la variable d'environnement associée (`S3_LOCATION`), cf. [doc](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html)

## 🏕 Amélioration continue
- [x] Ajout d'un setting/variable d'environnement pour pouvoir configurer `MEDIA_ROOT` ([doc](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-MEDIA_ROOT))
- [x] Passage de `STATIC_ROOT` à un chemin absolu, conformément à [la doc](https://docs.djangoproject.com/en/4.2/ref/settings/#static-root).
- [x] Déplacement des commentaires du `.env.example` sur des lignes dédiées (`dotenv` les prend en compte comme des valeurs sinon)
- [x] Ajout de `AWS_S3_FILE_OVERWRITE=False`, comme indiqué dans [la doc](https://docs.wagtail.org/en/stable/advanced_topics/deploying.html#cloud-storage)
