### PR TITLE
Ajout des liens d'évitement

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -101,6 +101,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "wagtail.contrib.settings.context_processors.settings",
                 "wagtailmenus.context_processors.wagtailmenus",
+                "content_manager.context_processors.skiplinks",
             ],
         },
     },

--- a/content_manager/context_processors.py
+++ b/content_manager/context_processors.py
@@ -1,0 +1,7 @@
+def skiplinks(request):
+    return {
+        "skiplinks": [
+            {"link": "#content", "label": "Contenu"},
+            {"link": "#fr-navigation", "label": "Menu"},
+        ]
+    }

--- a/content_manager/models.py
+++ b/content_manager/models.py
@@ -61,6 +61,15 @@ class ContentPage(Page):
         index.SearchField("body"),
     ]
 
+    def get_context(self, request, *args, **kwargs):
+        context = super().get_context(request, *args, **kwargs)
+
+        context["skiplinks"] = [
+            {"link": "#content", "label": "Contenu"},
+            {"link": "#fr-navigation", "label": "Menu"},
+        ]
+        return context
+
 
 class MonospaceField(models.TextField):
     """

--- a/content_manager/models.py
+++ b/content_manager/models.py
@@ -61,15 +61,6 @@ class ContentPage(Page):
         index.SearchField("body"),
     ]
 
-    def get_context(self, request, *args, **kwargs):
-        context = super().get_context(request, *args, **kwargs)
-
-        context["skiplinks"] = [
-            {"link": "#content", "label": "Contenu"},
-            {"link": "#fr-navigation", "label": "Menu"},
-        ]
-        return context
-
 
 class MonospaceField(models.TextField):
     """


### PR DESCRIPTION
## 🎯 Objectif
Les liens d’évitement permettent aux utilisateurs naviguant au clavier, ou équipés de lecteurs d'écran, d’accéder plus rapidement à des zones précises de la page. 

## 🔍 Implémentation
- [x] La balise `{% dsfr_skiplinks %}` était déjà présente dans le template `base.html`, mais le contexte n'était pas fourni : ajout d'un `context_processor` pour les fournir.

## 🖼️ Images
![Capture d’écran du 2024-01-22 10-45-42](https://github.com/numerique-gouv/content-manager/assets/765956/36459202-099c-4002-ac07-2c87631ef1c3)
