### PR TITLE
Mise à jour de la configuration des storages

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -196,7 +196,6 @@ if os.getenv("S3_HOST"):
         },
     }
 
-    # DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     MEDIA_URL = f"{endpoint_url}/"
 else:
     STORAGES["default"] = {

--- a/config/settings.py
+++ b/config/settings.py
@@ -166,6 +166,10 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 # https://whitenoise.evans.io/en/latest/
+STORAGES = {}
+STORAGES["staticfiles"] = {
+    "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+}
 
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -177,17 +181,27 @@ STATICFILES_FINDERS = [
 # ------------------------------------------------------------------------------
 
 if os.getenv("S3_HOST"):
-    AWS_S3_ACCESS_KEY_ID = os.getenv("S3_KEY_ID", "123")
-    AWS_S3_SECRET_ACCESS_KEY = os.getenv("S3_KEY_SECRET", "secret")
-    AWS_S3_ENDPOINT_URL = f"{os.getenv('S3_PROTOCOL', 'https')}://{os.getenv('S3_HOST')}"
-    AWS_STORAGE_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "set-bucket-name")
-    AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_BUCKET_REGION", "fr")
-    AWS_S3_FILE_OVERWRITE = False
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-    MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"
-    AWS_LOCATION = os.getenv("S3_LOCATION", "")
+    endpoint_url = f"{os.getenv('S3_PROTOCOL', 'https')}://{os.getenv('S3_HOST')}"
+
+    STORAGES["default"] = {
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": {
+            "bucket_name": os.getenv("S3_BUCKET_NAME", "set-bucket-name"),
+            "access_key": os.getenv("S3_KEY_ID", "123"),
+            "secret_key": os.getenv("S3_KEY_SECRET", "secret"),
+            "endpoint_url": endpoint_url,
+            "region_name": os.getenv("S3_BUCKET_REGION", "fr"),
+            "file_overwrite": False,
+            "location": os.getenv("S3_LOCATION", ""),
+        },
+    }
+
+    # DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    MEDIA_URL = f"{endpoint_url}/"
 else:
-    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+    STORAGES["default"] = {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    }
     MEDIA_URL = "medias/"
     MEDIA_ROOT = os.path.join(BASE_DIR, os.getenv("MEDIA_ROOT", ""))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,17 +131,17 @@ webencodings = "*"
 
 [[package]]
 name = "boto3"
-version = "1.34.42"
+version = "1.34.51"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.42-py3-none-any.whl", hash = "sha256:5069b2c647c73c8428378e88b32bd23f568001f897a6f01179fae25de72a7ca6"},
-    {file = "boto3-1.34.42.tar.gz", hash = "sha256:2ed136f9cf79e783e12424db23e970d1c50e65a8d7a9077efa71cbf8496fb7a3"},
+    {file = "boto3-1.34.51-py3-none-any.whl", hash = "sha256:67732634dc7d0afda879bd9a5e2d0818a2c14a98bef766b95a3e253ea5104cb9"},
+    {file = "boto3-1.34.51.tar.gz", hash = "sha256:2cd9463e738a184cbce8a6824027c22163c5f73e277a35ff5aa0fb0e845b4301"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.42,<1.35.0"
+botocore = ">=1.34.51,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -150,13 +150,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.42"
+version = "1.34.51"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.42-py3-none-any.whl", hash = "sha256:93755c3ede4bd9f6180b3118f6b607acca8b633fd2668226794a543ce79a2434"},
-    {file = "botocore-1.34.42.tar.gz", hash = "sha256:cf4fad50d09686f03e44418fcae9dd24369658daa556357cedc0790cfcd6fdac"},
+    {file = "botocore-1.34.51-py3-none-any.whl", hash = "sha256:01d5156247f991b3466a8404e3d7460a9ecbd9b214f9992d6ba797d9ddc6f120"},
+    {file = "botocore-1.34.51.tar.gz", hash = "sha256:5086217442e67dd9de36ec7e87a0c663f76b7790d5fb6a12de565af95e87e319"},
 ]
 
 [package.dependencies]
@@ -575,6 +575,7 @@ files = [
 ]
 
 [package.dependencies]
+boto3 = {version = ">=1.4.4", optional = true, markers = "extra == \"s3\""}
 Django = ">=3.2"
 
 [package.extras]
@@ -2140,4 +2141,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "44f07bdf147d690da0972eca8248083289fa83e99d3e81612c65579fbfc02c1d"
+content-hash = "632f14eb29fd991206da576b14b6341c8af9389a548a5544783410f59d25f5ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,10 @@ django-sass-processor = "^1.3"
 libsass = "^0.22.0"
 dj-static = "^0.0.6"
 wagtailmenus = "^3.1.9"
-boto3 = "^1.29.1"
-django-storages = "^1.14.2"
 wagtail-modeladmin = "^1.0.0"
 wagtail-markdown = "^0.11.1"
 unidecode = "^1.3.8"
+django-storages = {extras = ["s3"], version = "^1.14.2"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 🎯 Objectif
- Résolution de bug: lors d'un déploiement sur Scalingo, le site a parfois du mal à contacter le S3 (cf #75  mais cela arrive à d'autres déploiements que le premier), qui répond par une erreur 400 (et Django renvoie alors une erreur 500)

Il semblerait que spécifier la région (cf. [Stackoverflow](https://stackoverflow.com/questions/70096788/clienterror-headobject-when-collecstatic-aws-s3)) puisse résoudre le problème. On avait un paramètre pour préciser la région (`S3_BUCKET_REGION`) mais je ne le trouve pas dans la doc, où le paramètre est nommé `region_name` ou `AWS_S3_REGION_NAME`.


## 🔍 Implémentation
- [x] Réécriture des paramètres de stockage en utilisant le nouveau format défini depuis Django 4.2.
