### PR TITLE
Ajout de taggit comme dépendance directe

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2142,4 +2142,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "942287fdc0dffbf1d664db730af498c5bbdb87f2d84795ccaa7a9874da49b81d"
+content-hash = "8ca0434c6c3e843bd13548ad1d81ec92b5a081c0e9043f29e6620b0b035d4722"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ unidecode = "^1.3.8"
 django-storages = {extras = ["s3"], version = "^1.14.2"}
 boto3 = "^1.34.56"
 beautifulsoup4 = "^4.12.3"
+django-taggit = "^5.0.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 🎯 Objectif
Le déploiement échoue parfois sur Scalingo parce que le cache a enregistré une trop vieille version de taggit. Ajout en dépendance directe dans l'espoir d'améliorer les choses (bien que Wagtail lui-même ait taggit comme dépendance)

## 🔍 Implémentation
- [x] Ajout de `django-taggit` comme dépendance directe