### PR TITLE
Ajout du aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+gettext


### PR DESCRIPTION
## 🎯 Objectif
Il manque une dépendance apt pour la gestion des traductions

## 🔍 Implémentation
- [x] Ajout d'un `Aptfile` contenant `gettext`
